### PR TITLE
Apply escapeshellarg before defining the WPACCEPTANCE_DIR constant

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -11,7 +11,7 @@ use \Symfony\Component\Console\Application;
 
 $app = new Application( 'WPAcceptance', '0.13' );
 
-define( 'WPACCEPTANCE_DIR', dirname( __DIR__ ) );
+define( 'WPACCEPTANCE_DIR', escapeshellarg( dirname( __DIR__ ) ) );
 
 /**
  * Attempt to set this as WP Acceptance can consume a lot of memory.


### PR DESCRIPTION
Hey guys. How are you all?

First of all, thanks for the amazing library. WPAcceptance is everything we needed and is taking a lot of the stress out of letting new releases out!

So WPACCEPTANCE_DIR is used all around in shell commands, but the dir strings were not properly escaped for shell environments. We use Local by Flywheel for development and the sites folder is called "Local Sites". Since the string is not escaped, it breaks on the first cd command:

![image](https://user-images.githubusercontent.com/4679684/54689331-0eaedc00-4afe-11e9-9582-52e00cc107b5.png)

This PR simply wrappers the dir() function on the WPACCEPTANCE_DIR definition statement in an [escapeshellarg()](http://php.net/manual/en/function.escapeshellarg.php).

I'm not sure if you guys are accepting public contributions or not, so I figured I would just open a PR anyway.

Again, thanks for the work! I'm a huge fan =)