### PR TITLE
Improve/snapshots logging

### DIFF
--- a/src/classes/Command/Run.php
+++ b/src/classes/Command/Run.php
@@ -214,13 +214,13 @@ class Run extends Command {
 						'snapshot_name' => 'Snapshot from snapshot_id',
 					];
 
-			}
+				}
 
 			} else {
-			$new_snapshots[] = [
-				'snapshot_id' => $suite_config['snapshot_id'],
+					$new_snapshots[] = [
+						'snapshot_id' => $suite_config['snapshot_id'],
 						'snapshot_name' => 'Snapshot from snapshot_id',
-			];
+					];
 			}
 
 			$suite_config['snapshots'] = $new_snapshots;
@@ -379,6 +379,7 @@ class Run extends Command {
 
 					continue;
 				}
+				Log::instance()->write( sprintf( 'Running test for %s.', $snapshot_array['snapshot_name'] ), 0, 'success' );
 
 				$result = $this->runTests( $suite_config, $input, $output );
 

--- a/src/classes/Command/Run.php
+++ b/src/classes/Command/Run.php
@@ -202,19 +202,26 @@ class Run extends Command {
 
 		// Add snapshot_id to snapshots
 		if ( ! empty( $suite_config['snapshot_id'] ) ) {
-			$new_snapshots = [];
-
 			if ( ! empty( $suite_config['snapshots'] ) ) {
-				foreach ( $suite_config['snapshots'] as $key => $snapshot_array ) {
-					if ( $snapshot_array['snapshot_id'] !== $suite_config['snapshot_id'] ) {
-						$new_snapshots[] = $snapshot_array;
-					}
-				}
+				$new_snapshots = $suite_config['snapshots'];
+				$snapshot_ids = array_column( $suite_config['snapshots'], 'snapshot_id' );
+				$snapshot_id_in_snapshots = in_array( $suite_config['snapshot_id'], $snapshot_ids, true );
+
+				// Add the snapshot_id if not already in the array.
+				if ( ! $snapshot_id_in_snapshots ) {
+					$new_snapshots[] = [
+						'snapshot_id' => $suite_config['snapshot_id'],
+						'snapshot_name' => 'Snapshot from snapshot_id',
+					];
+
 			}
 
+			} else {
 			$new_snapshots[] = [
 				'snapshot_id' => $suite_config['snapshot_id'],
+						'snapshot_name' => 'Snapshot from snapshot_id',
 			];
+			}
 
 			$suite_config['snapshots'] = $new_snapshots;
 		}

--- a/src/classes/Command/Run.php
+++ b/src/classes/Command/Run.php
@@ -379,7 +379,7 @@ class Run extends Command {
 
 					continue;
 				}
-				Log::instance()->write( sprintf( 'Running test for %s.', $snapshot_array['snapshot_name'] ), 0, 'success' );
+				Log::instance()->write( sprintf( 'Running tests for %s.', $snapshot_array['snapshot_name'] ), 0, 'success' );
 
 				$result = $this->runTests( $suite_config, $input, $output );
 


### PR DESCRIPTION
* Update logic for adding `snapshot_id` to array of `snapshots` if not already present - append to the end, preserving the test order.
* When running with named snapshots, log the snapshot name during runs:

`Running tests for [snapshot name]`