### PR TITLE
WIP: Add support for running wp cli commands in test cases

### DIFF
--- a/src/classes/Environment.php
+++ b/src/classes/Environment.php
@@ -1822,6 +1822,61 @@ class Environment {
 	}
 
 	/**
+	 * WP CLI Runner
+	 *
+	 * @param string  $command A WP CLI command.
+	 * @return array
+	 */
+	public function wpCliRunner( $command ) {
+		Log::instance()->write( 'Running wp command: ' . $command, 0 );
+
+		$command = 'wp ' . $command . ' --allow-root';
+
+		$exec_config = new ContainersIdExecPostBody();
+		$exec_config->setTty( true );
+		$exec_config->setAttachStdout( true );
+		$exec_config->setAttachStderr( true );
+		$exec_config->setCmd( [ '/bin/bash', '-c', $command ] );
+
+		$exec_command      = EnvironmentFactory::$docker->containerExec( $this->environment_id . '-wordpress', $exec_config );
+		$exec_id           = $exec_command->getId();
+		$exec_start_config = new ExecIdStartPostBody();
+		$exec_start_config->setDetach( false );
+
+		$stream = EnvironmentFactory::$docker->execStart( $exec_id, $exec_start_config );
+		$output = '';
+		$error = '';
+
+		$stream->onStdout(
+			function( $_stdout ) use ( &$output ) {
+				$output .= $_stdout;
+			}
+		);
+
+		$stream->onStderr(
+			function( $_stderr ) use ( &$error ) {
+				$error .= $_stderr;
+			}
+		);
+
+		$stream->wait();
+
+		$exit_code = EnvironmentFactory::$docker->execInspect( $exec_id )->getExitCode();
+
+		if ( 0 !== $exit_code ) {
+			Log::instance()->write( 'Before script returned a non-zero exit code: ' . $script, 0, 'warning' );
+		}
+
+		$result = [
+			'stdOut' => $output,
+			'stdErr' => $error,
+			'code'   => $exit_code,
+		];
+
+		return $result;
+	}
+
+	/**
 	 * Generate an environment ID from config. This is a cache of critical suite config parameters
 	 *
 	 * @param  array $suite_config Suite config

--- a/src/classes/Environment.php
+++ b/src/classes/Environment.php
@@ -1824,7 +1824,7 @@ class Environment {
 	/**
 	 * WP CLI Runner
 	 *
-	 * @param string  $command A WP CLI command.
+	 * @param string $command A WP CLI command.
 	 * @return array
 	 */
 	public function wpCliRunner( $command ) {
@@ -1845,17 +1845,19 @@ class Environment {
 
 		$stream = EnvironmentFactory::$docker->execStart( $exec_id, $exec_start_config );
 		$output = '';
-		$error = '';
+		$error  = '';
 
 		$stream->onStdout(
-			function( $_stdout ) use ( &$output ) {
-				$output .= $_stdout;
+			function( $stdout ) use ( &$output ) {
+				Log::instance()->write( $stdout, 1 );
+				$output .= $stdout;
 			}
 		);
 
 		$stream->onStderr(
-			function( $_stderr ) use ( &$error ) {
-				$error .= $_stderr;
+			function( $stderr ) use ( &$error ) {
+				Log::instance()->write( $stderr, 1 );
+				$error .= $stderr;
 			}
 		);
 
@@ -1868,8 +1870,8 @@ class Environment {
 		}
 
 		$result = [
-			'stdOut' => $output,
-			'stdErr' => $error,
+			'stdout' => $output,
+			'stderr' => $error,
 			'code'   => $exit_code,
 		];
 

--- a/src/classes/PHPUnit/TestCase.php
+++ b/src/classes/PHPUnit/TestCase.php
@@ -16,7 +16,7 @@ use PHPUnit\Runner\BaseTestRunner;
  */
 abstract class TestCase extends \PHPUnit\Framework\TestCase {
 
-	use Puppeteer, Database, StandardTests\Backend, StandardTests\Frontend;
+	use Puppeteer, Database, WpCLI, StandardTests\Backend, StandardTests\Frontend;
 
 	/**
 	 * Store the last modifying query in the DB. We do this to determine if the DB is dirty (has changed)
@@ -90,5 +90,4 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 			$this->browser->close();
 		}
 	}
-
 }

--- a/src/classes/PHPUnit/WpCLI.php
+++ b/src/classes/PHPUnit/WpCLI.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * WP CLI helper to integratate with test class.
+ *
+ * @package  wpacceptance
+ */
+
+namespace WPAcceptance\PHPUnit;
+
+use WPAcceptance\EnvironmentFactory;
+
+/**
+ * WP CLI utility runner to integrate with test class.
+ */
+trait WpCLI {
+
+	/**
+	 * Run command.
+	 *
+	 * @param  string $command A WP ClI command.
+	 * @return array
+	 */
+	public function runCommand( $command ) {
+		return EnvironmentFactory::get()->wpCliRunner( $this->sanitizeCommand( $command ) );
+	}
+
+	/**
+	 * Sanitize command.
+	 *
+	 * @param  string $command The command to sanitize.
+	 * @return string
+	 */
+	protected function sanitizeCommand( $command ) {
+		if ( 0 === strpos( $command, 'wp' ) ) {
+			$command = substr( $command, 2 );
+		}
+
+		return trim( $command );
+	}
+}


### PR DESCRIPTION
This pull requests adds support for running wp cli commands in test cases.

Example use case:  We have a form that updates an option.  This option influences how the application behaves, but doesn't have an obvious UI element that the Actor can test.

Example usage:
```php
/**
 * @testdox The form field updates the option in the database.
 */
public function testExampleOption() {
    $I = $this->openBrowserPage();
    $I->moveTo( '/page' );
    
    // Set option via form in admin.
    $I->fillField( '#foo', 'bar' );
    $I->submit( '#form' );

    // Ensure option is set correctly.
    $command = $this->runCommand( 'wp option get foo' );
    $this->assertIsArray( $command );
    $this->assertEquals( $command['stdOut'], 'bar' );
} 
```

To Do: Add more documentation