### PR TITLE
Fix a typo that was causing undefined variable errors

### DIFF
--- a/src/classes/PHPUnit/Actor.php
+++ b/src/classes/PHPUnit/Actor.php
@@ -565,7 +565,7 @@ class Actor {
 	/**
 	 * Return elements based on CSS selector.
 	 *
-	 * @param  array $elements Elements to get
+	 * @param  array|string $elements Elements to get
 	 * @return  array Array of ElementHandle
 	 */
 	public function getElements( $elements ) {
@@ -576,7 +576,7 @@ class Actor {
 				if ( $element instanceof ElementHandle ) {
 					$items[] = $element;
 				} else {
-					$items[] = $this->getElement( $lement );
+					$items[] = $this->getElement( $element );
 				}
 			}
 
@@ -696,7 +696,7 @@ class Actor {
 	/**
 	 * Check a checkbox or radio input.
 	 *
-	 * @param  array $elements Array of ElementHandle or selector string
+	 * @param  array|string $elements Array of ElementHandle or selector string
 	 */
 	public function checkOptions( $elements ) {
 		$elements = $this->getElements( $elements );


### PR DESCRIPTION
If you pass in an array of strings to `getElements` (not a single string or an array of `ElementHandle` objects), the code that runs has a typo in it, causing undefined variable errors. I've fixed this and also adjusted a couple docblocks to specify the param can be either an `array` or `string`.