### PR TITLE
Add a method that can be used to log out a user from WordPress.

### DIFF
--- a/src/classes/PHPUnit/Actor.php
+++ b/src/classes/PHPUnit/Actor.php
@@ -694,6 +694,21 @@ class Actor {
 	}
 
 	/**
+	 * Logout from WordPress.
+	 */
+	public function logout() {
+		$this->moveTo( 'wp-login.php?action=logout' );
+
+		$this->waitUntilElementVisible( '#error-page' );
+
+		$this->click( '#error-page a' );
+
+		usleep( 200 );
+
+		$this->waitUntilElementVisible( '#loginform' );
+	}
+
+	/**
 	 * Check a checkbox or radio input.
 	 *
 	 * @param  array|string $elements Array of ElementHandle or selector string


### PR DESCRIPTION
### Description of the Change

We currently have a method to log in to WordPress, as a certain user, but no built-in way to logout from WordPress. This PR adds a new method that can be used to logout the current user.

### Alternate Designs

Initial approach here was to mimic how a real user would log out, namely by hovering over your profile name in the top right corner and then clicking on the Log Out link. In testing, this would fail about 25% of the time, due to issues with how this menu is shown on hover (there's probably a way to make this work that I wasn't finding).

The approach I ended up using was to go straight to the logout page, which has a link you can click on to log out. Using this approach, log outs have worked every time.

### Benefits

If tests require a user to login, modify something and then view the site in a logged out mode, this makes it easier to accomplish without writing custom code.

### Possible Drawbacks

None

### Verification Process

I've written some tests for the Restricted Site Access plugin that uses this code. A user logs in, changes some settings and then logs out to verify those settings are working as expected.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] (na) My change requires a change to the documentation.
- [x] (na) I have updated the documentation accordingly.
