### PR TITLE
PHP 7.4 Compatibility

### DIFF
--- a/src/classes/PHPUnit/Database.php
+++ b/src/classes/PHPUnit/Database.php
@@ -8,6 +8,7 @@
 namespace WPAcceptance\PHPUnit;
 
 use WPAcceptance\EnvironmentFactory;
+use WPAcceptance\Log;
 
 /**
  * Database trait
@@ -17,7 +18,7 @@ trait Database {
 	/**
 	 * Get the last INSERT, UPDATE, or DELETE that happened in the MySQL server
 	 *
-	 * @return array
+	 * @return array|null
 	 */
 	protected function getLastModifyingQuery() {
 		$mysql = EnvironmentFactory::get()->getMySQLClient();

--- a/src/classes/PHPUnit/TestCase.php
+++ b/src/classes/PHPUnit/TestCase.php
@@ -64,7 +64,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 
 		$new_last_modifying_query = $this->getLastModifyingQuery();
 
-		if ( ! empty( $new_last_modifying_query ) && $new_last_modifying_query['event_time'] !== $this->last_modifying_query['event_time'] ) {
+		if ( ! empty( $this->last_modifying_query ) && ! empty( $new_last_modifying_query ) && $new_last_modifying_query['event_time'] !== $this->last_modifying_query['event_time'] ) {
 			Log::instance()->write( 'Test modified the database (' . $this->getName() . ').', 1, 'warning' );
 			Log::instance()->write( 'Last query at ' . $new_last_modifying_query['event_time'] . ': ' . $new_last_modifying_query['argument'], 2 );
 


### PR DESCRIPTION
### Description of the Change

As described in #19, after updating to PHP 7.4, the `Trying to access array offset on value of type null` error is triggered. It seems to be related to this [backward incompatible change](https://www.php.net/manual/de/migration74.incompatible.php#migration74.incompatible.core.non-array-access).

This PR changes the `tearDown()` method of the `TestCase` class, checking if the `$last_modifying_query` attribute is not empty before using it as an array.

Additionally, it also changes the Database class:
- Pointing to the right Log class
- Updating the `getLastModifyingQuery()` return doc

### Alternate Designs

N/A.

### Benefits

PHP 7.4 Compatibility.

### Possible Drawbacks

As far as I can see, none.

### Verification Process

Just a couple of manual verifications using an already setup project.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Fix #19 

### Changelog Entry

Fixed PHP 7.4 Compatibility

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
