### PR TITLE
Fix: Database update prompt

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -9,7 +9,7 @@ namespace WPAcceptance;
 
 use \Symfony\Component\Console\Application;
 
-$app = new Application( 'WPAcceptance', '0.16.8' );
+$app = new Application( 'WPAcceptance', '0.16.9' );
 
 define( 'WPACCEPTANCE_DIR', dirname( __DIR__ ) );
 

--- a/src/classes/PHPUnit/Actor.php
+++ b/src/classes/PHPUnit/Actor.php
@@ -697,6 +697,20 @@ class Actor {
 			// Do nothing
 		}
 
+		// Fix Update WordPress Database prompt
+		try {
+			sleep(1);
+			if ( 'Database Update Required' === $this->getElementInnerText( 'body > h1' ) ) {
+				$this->click( '.step a.button' );
+			}
+			sleep(1);
+			if ( 'Update Complete' === $this->getElementInnerText( 'body > h1' ) ) {
+				$this->click( '.step a.button' );
+			}
+		} catch ( \Exception $exception ) {
+			// Do nothing
+		}
+
 		$this->waitUntilElementVisible( '#wpadminbar' );
 	}
 

--- a/src/classes/PHPUnit/Actor.php
+++ b/src/classes/PHPUnit/Actor.php
@@ -697,20 +697,6 @@ class Actor {
 			// Do nothing
 		}
 
-		// Fix Update WordPress Database prompt
-		try {
-			sleep(1);
-			if ( 'Database Update Required' === $this->getElementInnerText( 'body > h1' ) ) {
-				$this->click( '.step a.button' );
-			}
-			sleep(1);
-			if ( 'Update Complete' === $this->getElementInnerText( 'body > h1' ) ) {
-				$this->click( '.step a.button' );
-			}
-		} catch ( \Exception $exception ) {
-			// Do nothing
-		}
-
 		$this->waitUntilElementVisible( '#wpadminbar' );
 	}
 

--- a/src/classes/PHPUnit/TestCase.php
+++ b/src/classes/PHPUnit/TestCase.php
@@ -38,6 +38,9 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 		if ( ! empty( $this->last_modifying_query ) ) {
 			Log::instance()->write( 'Last modifying query at ' . $this->last_modifying_query['event_time'] . ': ' . $this->last_modifying_query['argument'], 2 );
 		}
+
+		// Fix Update WordPress Database prompt
+		$this->runCommand( 'wp core update-db' );
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes the Database update issue for snapshots that have out-of-date database. This is useful for snapshots use `latest` or `nightly` WP version.
